### PR TITLE
Add custom minecraft jar version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -56,7 +56,7 @@ curl --silent -o ngrok.zip -L "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable
 unzip ngrok.zip -d $BUILD_DIR/bin > /dev/null 2>&1
 echo "done"
 
-if [ -n $CUSTOM_MINECRAFT_VERSION ]; then
+if [ -n "${CUSTOM_MINECRAFT_VERSION:-""}" ]; then
   minecraft_version=${MINECRAFT_VERSION:-"1.11.2"}
   minecraft_url="https://s3.amazonaws.com/Minecraft.Download/versions/${minecraft_version}/minecraft_server.${minecraft_version}.jar"
 

--- a/bin/compile
+++ b/bin/compile
@@ -56,7 +56,7 @@ curl --silent -o ngrok.zip -L "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable
 unzip ngrok.zip -d $BUILD_DIR/bin > /dev/null 2>&1
 echo "done"
 
-if [ -n "${CUSTOM_MINECRAFT_VERSION:-""}" ]; then
+if [ ! "${CUSTOM_MINECRAFT_VERSION:-""}" ]; then
   minecraft_version=${MINECRAFT_VERSION:-"1.11.2"}
   minecraft_url="https://s3.amazonaws.com/Minecraft.Download/versions/${minecraft_version}/minecraft_server.${minecraft_version}.jar"
 

--- a/bin/compile
+++ b/bin/compile
@@ -56,13 +56,15 @@ curl --silent -o ngrok.zip -L "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable
 unzip ngrok.zip -d $BUILD_DIR/bin > /dev/null 2>&1
 echo "done"
 
-minecraft_version=${MINECRAFT_VERSION:-"1.11.2"}
-minecraft_url="https://s3.amazonaws.com/Minecraft.Download/versions/${minecraft_version}/minecraft_server.${minecraft_version}.jar"
+if [ -n $CUSTOM_MINECRAFT_VERSION ]; then
+  minecraft_version=${MINECRAFT_VERSION:-"1.11.2"}
+  minecraft_url="https://s3.amazonaws.com/Minecraft.Download/versions/${minecraft_version}/minecraft_server.${minecraft_version}.jar"
 
-echo -n "-----> Installing Minecraft ${minecraft_version}... "
-curl -o minecraft.jar -s -L $minecraft_url
-mv minecraft.jar $BUILD_DIR/minecraft.jar
-echo "done"
+  echo -n "-----> Installing Minecraft ${minecraft_version}... "
+  curl -o minecraft.jar -s -L $minecraft_url
+  mv minecraft.jar $BUILD_DIR/minecraft.jar
+  echo "done"
+fi
 
 if [ -n "${MINECRAFT_EULA:-""}" ]; then
   echo -n "-----> Accepting Minecraft EULA... "


### PR DESCRIPTION
In case the user wants to use a custom Minecraft jar (like bukkit or spigot) they should be allowed to supply their own `minecraft.jar` without it getting replaced.