### PR TITLE
Run Minecraft server under screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ screen -r minecraft
 ```
 
 **WARNING** You are now connected to the Minecraft server. Use `Ctrl-A Ctrl-D` to exit the screen session. 
-(If you hit `Ctrl-C` while in the session, you'll terminate the Minecraft server.
+(If you hit `Ctrl-C` while in the session, you'll terminate the Minecraft server.)
 
 ## Customizing
 

--- a/README.md
+++ b/README.md
@@ -64,13 +64,19 @@ The buildpack will sync your world to the bucket every 60 seconds, but this is c
 
 ## Connecting to the server console
 
-The Minecraft server runs inside a screen session. You can use [Heroku Exec](https://devcenter.heroku.com/articles/heroku-exec) to connect to your server console.
+The Minecraft server runs inside a `screen` session. You can use [Heroku Exec](https://devcenter.heroku.com/articles/heroku-exec) to connect to your server console.
 
 Once you have Heroku Exec installed, you can connect to the console using 
 
 ```
-$ heroku ps:exec screen -r minecraft
+$ heroku ps:exec
+Establishing credentials... done
+Connecting to web.1 on ⬢ lovely-minecraft-2351...
+$ screen -r minecraft
 ```
+
+**WARNING** You are now connected to the Minecraft server. Use `Ctrl-A Ctrl-D` to exit the screen session. 
+(If you hit `Ctrl-C` while in the session, you'll terminate the Minecraft server.
 
 ## Customizing
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ $ heroku config:set AWS_SECRET_KEY=xxx
 
 The buildpack will sync your world to the bucket every 60 seconds, but this is configurable by setting the `AWS_SYNC_INTERVAL` config var.
 
+## Connecting to the server console
+
+The Minecraft server runs inside a screen session. You can use [Heroku Exec](https://devcenter.heroku.com/articles/heroku-exec) to connect to your server console.
+
+Once you have Heroku Exec installed, you can connect to the console using 
+
+```
+$ heroku ps:exec screen -r minecraft
+```
+
 ## Customizing
 
 ### ngrok

--- a/bin/compile
+++ b/bin/compile
@@ -38,6 +38,7 @@ apt-get $APT_OPTIONS update | indent
 apt-get $APT_OPTIONS -y --force-yes -d install --reinstall s3cmd | indent
 echo "-----> Installing screen... "
 apt-get $APT_OPTIONS -y --force-yes -d install --reinstall screen | indent
+mkdir -p $BUILD_DIR/.apt/var/run/screen
 
 mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/000_apt.sh
@@ -49,6 +50,7 @@ export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
 export PYTHONPATH="\$HOME/.apt/usr/lib/python2.7/dist-packages"
+export SCREENDIR="\$HOME/.apt/var/run/screen"
 EOF
 
 for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do

--- a/bin/compile
+++ b/bin/compile
@@ -36,6 +36,9 @@ mkdir -p "$APT_STATE_DIR/lists/partial"
 echo "-----> Installing s3cmd... "
 apt-get $APT_OPTIONS update | indent
 apt-get $APT_OPTIONS -y --force-yes -d install --reinstall s3cmd | indent
+echo "-----> Installing screen... "
+apt-get $APT_OPTIONS -y --force-yes -d install --reinstall screen | indent
+
 mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/000_apt.sh
 export PATH="\$HOME/.apt/usr/bin:\$PATH"

--- a/opt/minecraft
+++ b/opt/minecraft
@@ -41,7 +41,7 @@ case $limit in
 esac
 
 echo "Starting: minecraft ${mc_port}"
-eval "screen -h 2048 -dmS minecraft java -Xmx${heap} -Xms${heap} -jar minecraft.jar nogui"
+eval "screen -L -h 2048 -dmS minecraft java -Xmx${heap} -Xms${heap} -jar minecraft.jar nogui"
 main_pid=$!
 
 echo "Tailing log"

--- a/opt/minecraft
+++ b/opt/minecraft
@@ -41,10 +41,14 @@ case $limit in
 esac
 
 echo "Starting: minecraft ${mc_port}"
-eval "java -Xmx${heap} -Xms${heap} -jar minecraft.jar nogui &"
+eval "screen -h 2048 -dmS minecraft java -Xmx${heap} -Xms${heap} -jar minecraft.jar nogui"
 main_pid=$!
 
-trap "kill $ngrok_pid $main_pid $sync_pid" SIGTERM
-trap "kill -9 $ngrok_pid $main_pid $sync_pid; exit" SIGKILL
+echo "Tailing log"
+eval "tail -f screenlog.0 &"
+tail_pid=$!
+
+trap "kill $ngrok_pid $main_pid $sync_pid $tail_pid" SIGTERM
+trap "kill -9 $ngrok_pid $main_pid $sync_pid $tail_pid; exit" SIGKILL
 
 eval "ruby -rwebrick -e'WEBrick::HTTPServer.new(:BindAddress => \"0.0.0.0\", :Port => ${port}, :MimeTypes => {\"rhtml\" => \"text/html\"}, :DocumentRoot => Dir.pwd).start'"

--- a/opt/minecraft
+++ b/opt/minecraft
@@ -44,6 +44,9 @@ echo "Starting: minecraft ${mc_port}"
 eval "screen -L -h 2048 -dmS minecraft java -Xmx${heap} -Xms${heap} -jar minecraft.jar nogui"
 main_pid=$!
 
+# Flush the logfile every second, and ensure that the logfile exists
+screen -X "logfile 1" && sleep 1
+
 echo "Tailing log"
 eval "tail -f screenlog.0 &"
 tail_pid=$!


### PR DESCRIPTION
This PR runs the minecraft server using screen which means that in combination with Heroku Exec, that gives us a way to connect to the server console. That's useful to initially give Ops access to players.