### PR TITLE
Minecraft 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ $ heroku config:set AWS_SECRET_KEY=xxx
 
 The buildpack will sync your world to the bucket every 60 seconds, but this is configurable by setting the `AWS_SYNC_INTERVAL` config var.
 
+## Connecting to the server console
+
+The Minecraft server runs inside a `screen` session. You can use [Heroku Exec](https://devcenter.heroku.com/articles/heroku-exec) to connect to your server console.
+
+Once you have Heroku Exec installed, you can connect to the console using 
+
+```
+$ heroku ps:exec
+Establishing credentials... done
+Connecting to web.1 on ⬢ lovely-minecraft-2351...
+$ screen -r minecraft
+```
+
+**WARNING** You are now connected to the Minecraft server. Use `Ctrl-A Ctrl-D` to exit the screen session. 
+(If you hit `Ctrl-C` while in the session, you'll terminate the Minecraft server.)
+
 ## Customizing
 
 ### ngrok

--- a/bin/compile
+++ b/bin/compile
@@ -62,7 +62,7 @@ curl --silent -o ngrok.zip -L "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable
 unzip ngrok.zip -d $BUILD_DIR/bin > /dev/null 2>&1
 echo "done"
 
-minecraft_version=${MINECRAFT_VERSION:-"1.11.2"}
+minecraft_version=${MINECRAFT_VERSION:-"1.12"}
 minecraft_url="https://s3.amazonaws.com/Minecraft.Download/versions/${minecraft_version}/minecraft_server.${minecraft_version}.jar"
 
 echo -n "-----> Installing Minecraft ${minecraft_version}... "

--- a/bin/compile
+++ b/bin/compile
@@ -45,6 +45,7 @@ export INCLUDE_PATH="\$HOME/.apt/usr/include:\$INCLUDE_PATH"
 export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
+export PYTHONPATH="\$HOME/.apt/usr/lib/python2.7/dist-packages"
 EOF
 
 for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do

--- a/bin/compile
+++ b/bin/compile
@@ -36,6 +36,10 @@ mkdir -p "$APT_STATE_DIR/lists/partial"
 echo "-----> Installing s3cmd... "
 apt-get $APT_OPTIONS update | indent
 apt-get $APT_OPTIONS -y --force-yes -d install --reinstall s3cmd | indent
+echo "-----> Installing screen... "
+apt-get $APT_OPTIONS -y --force-yes -d install --reinstall screen | indent
+mkdir -p $BUILD_DIR/.apt/var/run/screen
+
 mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/000_apt.sh
 export PATH="\$HOME/.apt/usr/bin:\$PATH"
@@ -46,6 +50,7 @@ export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
 export PYTHONPATH="\$HOME/.apt/usr/lib/python2.7/dist-packages"
+export SCREENDIR="\$HOME/.apt/var/run/screen"
 EOF
 
 for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do

--- a/opt/minecraft
+++ b/opt/minecraft
@@ -22,10 +22,9 @@ sync_pid=$!
 
 # create server config
 echo "server-port=${mc_port}" >> /app/server.properties
-touch whitelist.json
-touch banned-players.json
-touch banned-ips.json
-touch ops.json
+for f in whitelist banned-players banned-ips ops; do
+  test ! -f $f.json && echo -n "[]" > $f.json
+done
 
 limit=$(ulimit -u)
 case $limit in

--- a/opt/minecraft
+++ b/opt/minecraft
@@ -41,10 +41,17 @@ case $limit in
 esac
 
 echo "Starting: minecraft ${mc_port}"
-eval "java -Xmx${heap} -Xms${heap} -jar minecraft.jar nogui &"
+eval "screen -L -h 2048 -dmS minecraft java -Xmx${heap} -Xms${heap} -jar minecraft.jar nogui"
 main_pid=$!
 
-trap "kill $ngrok_pid $main_pid $sync_pid" SIGTERM
-trap "kill -9 $ngrok_pid $main_pid $sync_pid; exit" SIGKILL
+# Flush the logfile every second, and ensure that the logfile exists
+screen -X "logfile 1" && sleep 1
+
+echo "Tailing log"
+eval "tail -f screenlog.0 &"
+tail_pid=$!
+
+trap "kill $ngrok_pid $main_pid $sync_pid $tail_pid" SIGTERM
+trap "kill -9 $ngrok_pid $main_pid $sync_pid $tail_pid; exit" SIGKILL
 
 eval "ruby -rwebrick -e'WEBrick::HTTPServer.new(:BindAddress => \"0.0.0.0\", :Port => ${port}, :MimeTypes => {\"rhtml\" => \"text/html\"}, :DocumentRoot => Dir.pwd).start'"


### PR DESCRIPTION
Empty JSON files crashes Minecraft 1.12, so create them as valid JSON (so that 1.11.2 don't complain about them missing).

Also makes the default version 1.12.

This also contains the changes from pythonpath, screen and the other documentation branches.